### PR TITLE
Add TWZRD Agent Intel — agent trust scoring for GraphQL API security

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ A curated list of awesome GraphQL Security frameworks, libraries, software, and 
 ### Security Solutions
 
 - [WAF for GraphQL](https://lab.wallarm.com/api-security-solution/) - Web Application Firewall for GraphQL APIs.
+- [TWZRD Agent Intel](https://intel.twzrd.xyz) - On-chain trust scoring for AI agent wallets on Solana. Verify agent identity before authorizing x402 micropayment-gated GraphQL API access. MCP: , . [MCP](https://intel.twzrd.xyz/mcp)
 
 ## Neutral Security
 


### PR DESCRIPTION
## What

Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) to the **Security Solutions** section.

## Entry

```
- [TWZRD Agent Intel](https://intel.twzrd.xyz) - On-chain trust scoring for AI agent wallets on Solana. Verify agent identity before authorizing x402 micropayment-gated GraphQL API access. MCP: `score_agent`, `preflight_check`. [MCP](https://intel.twzrd.xyz/mcp)
```

## Why it fits

As AI agents increasingly call GraphQL APIs autonomously (including paid/gated endpoints), the identity of the calling agent becomes a security primitive. TWZRD Agent Intel provides the trust layer: before an agent is permitted to call a sensitive or paid GraphQL mutation, operators can verify on-chain that the agent wallet has an established behavioral history — defense-in-depth for agentic API access control.

**MCP config:**
```json
{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}
```